### PR TITLE
fix(i18n): default to Turkish and set Turkish as fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="tr">
 <head>
     <meta charset="UTF-8"/>
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,11 @@ import Footer from './components/Footer';
 import ScrollReveal from './components/ScrollReveal';
 
 function App() {
-    const { t } = useTranslation();
+    const { t, i18n } = useTranslation();
+
+    React.useEffect(() => {
+        document.documentElement.lang = i18n.language;
+    }, [i18n.language]);
     
     return (
         <div className="relative min-h-screen bg-[#030014] text-text-primary overflow-hidden">

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -4,7 +4,7 @@ import en from './locales/en.json';
 import de from './locales/de.json';
 import tr from './locales/tr.json';
 
-const savedLanguage = localStorage.getItem('language') || 'en';
+const savedLanguage = localStorage.getItem('language') || 'tr';
 
 i18n.use(initReactI18next).init({
     resources: {
@@ -13,7 +13,7 @@ i18n.use(initReactI18next).init({
         tr: { translation: tr },
     },
     lng: savedLanguage,
-    fallbackLng: 'en',
+    fallbackLng: 'tr',
     interpolation: {
         escapeValue: false,
     },


### PR DESCRIPTION
### Summary
Turkish is set as the default UI language and as the fallback language for i18n. The application will load Turkish by default when no language is set and will fallback to Turkish for missing translations.

### Details
- Default language is now Turkish ('tr').
- Fallback language updated to 'tr' to ensure Turkish translations are used if others are missing.
- Language persistence via localStorage remains; existing English and German resources are preserved.
- HTML's initial lang attribute updated to 'tr' to reflect default language.
- App synchronizes the HTML lang attribute with the current i18n language on changes.
- i18n configuration persists the selected language to localStorage on changes.